### PR TITLE
added loggervin adapter.cpp

### DIFF
--- a/design_Patterns/Adapter.cpp
+++ b/design_Patterns/Adapter.cpp
@@ -1,24 +1,28 @@
 #include <iostream>
 #include "Adapter.hpp"
+#include "logger.hpp"
 using namespace std;
+void logTest(void);
+loglevel_e loglevel = logDEBUG2; // Define the log level variable
+
 void English::write()
 {
-    cout << " I am English, Standard language logs.\n";
+    log(logDEBUG1) <<  " I am English, Standard language logs.\n";
 }
 
 void English::standardTimings()
 {
-    cout << "convert to standard time zone\n";
+    log(logDEBUG1) <<  "convert to standard time zone\n";
 }
 
 void German::write()
 {
-    cout << "Uses German langugae for the logs.\n";
+    log(logDEBUG1) << "Uses German langugae for the logs.\n";
 }
 
 void German::standardTimings()
 {
-    cout << "Converted to German timings\n";
+    log(logDEBUG2) <<  "Converted to German timings\n";
 }
 
 void AdapterLangConverter::write()
@@ -38,6 +42,9 @@ void LogsConverter(ILanguage *lang)
 
 int main()
 {
+    //loglevel_e loglevel;
+
+   loglevel = logDEBUG2;
     ILanguage *eng = new English();
     eng->write();
     eng->standardTimings();
@@ -46,8 +53,28 @@ int main()
     ger->write();
     ger->standardTimings();
 
-    cout << "want the english language from German";
+    log(logDEBUG1) <<  "want the english language from German";
     AdapterLangConverter *alc = new AdapterLangConverter(ger);
     LogsConverter(alc);
+
+    //logTest();
     return 0;
+}
+
+void logTest(void) {
+    loglevel_e loglevel_save = loglevel;
+
+    loglevel_save = logDEBUG1;
+
+    log(logINFO) << "foo " << "bar " << "baz";
+
+    int count = 3;
+    log(logDEBUG) << "A loop with "    << count << " iterations";
+    for (int i = 0; i != count; ++i)
+    {
+        log(logDEBUG1) << "the counter i = " << i;
+        log(logDEBUG2) << "the counter i = " << i;
+    }
+
+    loglevel = loglevel_save;
 }

--- a/design_Patterns/logger.hpp
+++ b/design_Patterns/logger.hpp
@@ -1,0 +1,54 @@
+#ifndef _LOGGER_HPP_
+#define _LOGGER_HPP_
+
+#include <iostream>
+#include <sstream>
+
+/* consider adding boost thread id since we'll want to know whose writting and
+ * won't want to repeat it for every single call */
+
+/* consider adding policy class to allow users to redirect logging to specific
+ * files via the command line
+ */
+
+enum loglevel_e
+    {logERROR, logWARNING, logINFO, logDEBUG, logDEBUG1, logDEBUG2, logDEBUG3, logDEBUG4};
+
+class logIt
+{
+public:
+    logIt(loglevel_e _loglevel = logERROR) {
+        _buffer << _loglevel << " :" 
+            << std::string(
+                _loglevel > logDEBUG 
+                ? (_loglevel - logDEBUG) * 4 
+                : 1
+                , ' ');
+    }
+
+    template <typename T>
+    logIt & operator<<(T const & value)
+    {
+        _buffer << value;
+        return *this;
+    }
+
+    ~logIt()
+    {
+        _buffer << std::endl;
+        // This is atomic according to the POSIX standard
+        // http://www.gnu.org/s/libc/manual/html_node/Streams-and-Threads.html
+        std::cerr << _buffer.str();
+    }
+
+private:
+    std::ostringstream _buffer;
+};
+
+extern loglevel_e loglevel;
+
+#define log(level) \
+if (level > loglevel) ; \
+else logIt(level)
+
+#endif


### PR DESCRIPTION
https://stackoverflow.com/questions/6168107/how-to-implement-a-good-debug-logging-feature-in-a-project

In this example, only the messages with a log level equal to or higher than the loglevel setting (in this case, logINFO) will be printed to the standard error stream (std::cerr).

Please note that the code you provided assumes a certain level of thread safety based on the POSIX standard, but it does not explicitly implement any thread synchronization mechanisms. If you plan to use this logging class in a multi-threaded environment, you may need to add additional thread safety measures, such as mutexes, to ensure correct behavior.